### PR TITLE
Make it safer for incorrect use

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -41,6 +41,7 @@ const getGlobalBasePrefix = () =>
 
 const isLocalLink = path =>
   path &&
+  path.startsWith &&
   !path.startsWith(`http://`) &&
   !path.startsWith(`https://`) &&
   !path.startsWith(`//`)


### PR DESCRIPTION
It broke in my use case, where I'm using [`react-intl`](https://github.com/formatjs/formatjs/tree/main/packages/react-intl) to deal with language-specific URLs.
The API changed from v4 to v5, and now it seems that `children` [render function](https://formatjs.io/docs/react-intl/components#formattedmessage) receives and `array` instead of a `string`.


## Description

Adding the check to avoid problems...